### PR TITLE
Make 3 unneeded PODTicket fields optional

### DIFF
--- a/examples/test-app/src/apis/GPC.tsx
+++ b/examples/test-app/src/apis/GPC.tsx
@@ -210,13 +210,10 @@ const ticketData = {
   ticketName: "Ticket 1",
   eventName: "Event 1",
   ticketSecret: "secret123",
-  timestampConsumed: 1714857600,
   timestampSigned: 1714857600,
   attendeeSemaphoreId: ${identityV3},
   owner: "${publicKey}",
   isConsumed: 0,
-  isRevoked: 0,
-  ticketCategory: 0,
   attendeeName: "John Doe",
   attendeeEmail: "test@example.com"
 };
@@ -236,13 +233,13 @@ await z.pod.insert(pod);
                 ticketName: "Ticket 1",
                 eventName: "Event 1",
                 ticketSecret: "secret123",
-                timestampConsumed: 1714857600,
+                //timestampConsumed: 1714857600,
                 timestampSigned: 1714857600,
                 attendeeSemaphoreId: identityV3!,
                 owner: publicKey!,
                 isConsumed: 0,
-                isRevoked: 0,
-                ticketCategory: 0,
+                //isRevoked: 0,
+                //ticketCategory: 0,
                 attendeeName: "John Doe",
                 attendeeEmail: "test@example.com"
               };

--- a/packages/podspec/test/ticket-example.spec.ts
+++ b/packages/podspec/test/ticket-example.spec.ts
@@ -21,12 +21,12 @@ const TicketEntries = p.entries({
   imageUrl: { type: "optional", innerType: { type: "string" } },
   imageAltText: { type: "optional", innerType: { type: "string" } },
   ticketSecret: { type: "optional", innerType: { type: "string" } },
-  timestampConsumed: { type: "int" },
+  timestampConsumed: { type: "optional", innerType: { type: "int" } },
   timestampSigned: { type: "int" },
   attendeeSemaphoreId: { type: "cryptographic" },
   isConsumed: { type: "int" },
-  isRevoked: { type: "int" },
-  ticketCategory: { type: "string" },
+  isRevoked: { type: "optional", innerType: { type: "int" } },
+  ticketCategory: { type: "optional", innerType: { type: "int" } },
   attendeeName: { type: "string" },
   attendeeEmail: { type: "string" }
 });
@@ -51,12 +51,12 @@ const VALID_TICKET_DATA = {
   imageUrl: "https://example.com/image.jpg",
   imageAltText: "Image 1",
   ticketSecret: "secret123",
-  timestampConsumed: 1714857600,
+  //timestampConsumed: 1714857600,
   timestampSigned: 1714857600,
   attendeeSemaphoreId: 1234567890,
   isConsumed: 0,
-  isRevoked: 0,
-  ticketCategory: "Category 1",
+  //isRevoked: 0,
+  //ticketCategory: 1,
   attendeeName: "John Doe",
   attendeeEmail: "john.doe@example.com"
 };

--- a/packages/ticket-spec/src/ticket_spec.ts
+++ b/packages/ticket-spec/src/ticket_spec.ts
@@ -10,7 +10,7 @@ export const TicketSpec = p.pod({
     productId: { type: "string" },
     ticketName: { type: "string" },
     eventName: { type: "string" },
-    timestampConsumed: { type: "int" },
+    timestampConsumed: { type: "optional", innerType: { type: "int" } },
     timestampSigned: { type: "int" },
     // Semaphore v3
     attendeeSemaphoreId: {
@@ -20,8 +20,8 @@ export const TicketSpec = p.pod({
     // Semaphore v4
     owner: { type: "eddsa_pubkey" },
     isConsumed: { type: "int" },
-    isRevoked: { type: "int" },
-    ticketCategory: { type: "int" },
+    isRevoked: { type: "optional", innerType: { type: "int" } },
+    ticketCategory: { type: "optional", innerType: { type: "int" } },
     attendeeName: { type: "string" },
     attendeeEmail: { type: "string" },
     checkerEmail: { type: "optional", innerType: { type: "string" } },


### PR DESCRIPTION
Updates to parcnet-client types to match https://github.com/proofcarryingdata/zupass/pull/2151

I haven't been able to test this yet.  @robknight I trust you to take this from here.
